### PR TITLE
Give proper names and docs to size class function

### DIFF
--- a/exercises/Version-control-basic-7-R.md
+++ b/exercises/Version-control-basic-7-R.md
@@ -34,9 +34,9 @@ Fast-forward
 3\. You should see the new function in your repository.
 
 ```
-gc_content <- function(seq){
-   #Calculate the GC-content for one or more sequences
-   ear_lengths <- ifelse(seq > 10, "large", "small")
+get_size_class <- function(ear_length){
+   # Calculate the size class for one or more earth lengths
+   ear_lengths <- ifelse(ear_length > 10, "large", "small")
    return(ear_lengths)
 }
 ``` 


### PR DESCRIPTION
In the Version control basic 7 exercise the function to be added had a mix
of information about gc-content and size class due to copy-paste errors.