### PR TITLE
_config.yml: rdiscount to kramdown

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,4 @@
 # Dependencies
-markdown:         kramdown
 highlighter:      rouge
 
 # Permalinks

--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,9 @@
 # Dependencies
+markdown:         kramdown
 highlighter:      rouge
+
+kramdown:
+  input:          GFM
 
 # Permalinks
 permalink:        pretty

--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 # Dependencies
-markdown:         rdiscount
+markdown:         kramdown
 highlighter:      rouge
 
 # Permalinks

--- a/exercises/Data-analysis-R.md
+++ b/exercises/Data-analysis-R.md
@@ -6,14 +6,14 @@ language: R
 ---
 
 We are interested in understanding the monthly variation in precipitation in
-Gainesville, FL. We'll use some data from the
-[NOAA National Climatic Data Center](http://www.ncdc.noaa.gov/).
+Gainesville, FL. We'll use some data from the [NOAA National Climatic Data 
+Center](http://www.ncdc.noaa.gov/).
 
 Start by creating a `data` directory in the same directory as your homework
 scripts and then downloading [the data]({{ site.baseurl }}/data/gainesville_precip.csv) and saving it to this `data` directory.
 
-Each row of this data file is a year (from 1961-2013) and each column is a month
-(January- December).
+Each row of this data file is a year (from 1961-2013) and each column is a 
+month (January - December).
 
 Rearrange the following program so that it:
 
@@ -21,8 +21,8 @@ Rearrange the following program so that it:
 - Calculates the average precipitation in each month across years
 - Plots the monthly averages as a simple line plot
 
-Finally, add a comment above the code that describes what it does. The comment
-character in R is `#`.
+Finally, add a comment above the code that describes what it does. The 
+comment character in R is `#`.
 
 ```
 plot(monthly_mean_ppt, type = "l", xlab = "Month", ylab = "Mean Precipitation")

--- a/exercises/Expressions-variables-1-R.md
+++ b/exercises/Expressions-variables-1-R.md
@@ -5,9 +5,9 @@ subtitle: Basic Expressions
 language: R
 ---
 
-Think about what value each of the following expressions will return?
-Check your answers using the R Console by typing each expression into
-the console on the line marked `>` and pressing enter.
+Think about what value each of the following expressions will return? Check 
+your answers using the R Console by typing each expression into the console 
+on the line marked `>` and pressing enter.
 
 1. 2 - 10
 2. 3 \* 5
@@ -19,15 +19,13 @@ the console on the line marked `>` and pressing enter.
 
 Did any of the results surprise you? If so, then might have run in to some order of operations confusion. The order of operators in R are listed [HERE](http://stat.ethz.ch/R-manual/R-patched/library/base/html/Syntax.html).
 
-Now turn this set of expressions into a program that you can save by
-using an R script. For each expression add one line to the script as part
-of a print statement. Copy and paste the script into the console to display the answer to the screen. If you are using RStudio, you can use Ctrl+Enter (Windows & Linux) or Command+Enter (Mac) to run the line or selection of code directly from your script. 
+Now turn this set of expressions into a program that you can save by using an 
+R script. For each expression add one line to the script as part of a print 
+statement. Copy and paste the script into the console to display the answer to the screen. If you are using RStudio, you can use Ctrl+Enter (Windows & Linux) or Command+Enter (Mac) to run the line or selection of code directly from your script. 
 
-To tell someone reading the code what this section of the code is about,
-add a comment line that says 'Problem 1' before the code that answers
-the problem. Comments in R are added by adding the `#` sign.
-Anything after a `#` sign on the same line is ignored when the program is
-run. So, the start of your program should look something like:
+To tell someone reading the code what this section of the code is about, add a comment line that says 'Problem 1' before the code that answers the problem. Comments in R are added by adding the `#` sign. Anything after a `#` sign on 
+the same line is ignored when the program is run. So, the start of your program 
+should look something like:
 
     # Problem 1
     print(2-10)

--- a/exercises/Expressions-variables-2-R.md
+++ b/exercises/Expressions-variables-2-R.md
@@ -5,8 +5,8 @@ subtitle: Basic Variables
 language: R
 ---
 
-Here is a small program that converts a mass in kilograms to a mass in grams and
-then prints out the resulting value.
+Here is a small program that converts a mass in kilograms to a mass in grams 
+and then prints out the resulting value.
 
 ```
 mass_kg <- 2.62
@@ -15,9 +15,9 @@ print(mass_g)
 ```
 
 Modify this code to create a variable that stores a body mass in pounds and
-assign it a value of 3.5 (about the right size for a
-[Desert Cottontail Rabbit – *Sylvilagus audubonii*](https://en.wikipedia.org/wiki/Desert_Cottontail)). Convert
-this value to kilograms (we are serious scientists after all). There are
-approximately 2.2046 lbs in a kilogram, so divide the variable storing the
-weight in pounds by 2.2046 and store this value in a new variable for storing
-mass in kilograms. Print the value of the new variable to the screen.
+assign it a value of 3.5 (about the right size for a [Desert Cottontail Rabbit – 
+*Sylvilagus audubonii*](https://en.wikipedia.org/wiki/Desert_Cottontail)). Convert this value to kilograms (*we are serious scientists 
+after all*). There are approximately 2.2046 lbs in a kilogram, so divide the 
+variable storing the weight in pounds by 2.2046 and store this value in a new 
+variable for storing mass in kilograms. Print the value of the new variable to 
+the screen.

--- a/exercises/Expressions-variables-3-R.md
+++ b/exercises/Expressions-variables-3-R.md
@@ -5,31 +5,28 @@ subtitle: More Variables
 language: R
 ---
 
-Calculate a total biomass in grams for 3 white-throated woodrats
-([*Neotoma albigula*](https://en.wikipedia.org/wiki/White-throated_woodrat)) and then convert it to kilograms. The total biomass
-is simply the sum of the biomass of all individuals, but in this case we
-only know that the average size of a single individual is 250 grams.
+Calculate a total biomass in grams for 3 white-throated woodrats ([*Neotoma 
+albigula*](https://en.wikipedia.org/wiki/White-throated_woodrat)) and then convert it to kilograms. The total biomass is simply the sum 
+of the biomass of all individuals, but in this case we only know that the 
+average size of a single individual is 250 grams.
 
 1. Add a new section to your R script starting with a comment.
-2. Create a variable `grams` and assign it the mass of a single
-*Neotoma albigula*.
+2. Create a variable `grams` and assign it the mass of a single *Neotoma 
+albigula*.
 3. Create a variable `number` and assign it the number of individuals.
-4. Create a variable `biomass` and assign it a value by multiplying
-the two variables together.
-5. Convert the value of `biomass` into kilograms (there are 1000
-grams in a kilogram so divide by 1000) and assign this value to a new
-variable.
+4. Create a variable `biomass` and assign it a value by multiplying the two 
+variables together.
+5. Convert the value of `biomass` into kilograms (there are 1000 grams in a kilogram so divide by 1000) and assign this value to a new variable.
 6. Print the final answer to the screen.
 
-*Are the variable names `grams`, `number`, and `biomass` the best
-choice? If we came back to the code for this assignment in two weeks
-(without the assignment itself in hand) would we be able to remember
-what these variables were referring to and therefore what was going on
-in the code? The variable name `biomass` is also kind of long. If we
-had to type it many times it would be faster just to type `b`. We
-could also use really descriptive alternatives like
-`individual_mass_in_grams`. Or we would compromise and abbreviate
-this or leave out some of the words to make it shorter (e.g.,
-`indiv_mass_g`).* 
+*Are the variable names `grams`, `number`, and `biomass` the best choice? If we 
+came back to the code for this assignment in two weeks (without the assignment 
+itself in hand) would we be able to remember what these variables were referring 
+to and therefore what was going on in the code? The variable name `biomass` is 
+also kind of long. If we had to type it many times it would be faster just to 
+type `b`. We could also use really descriptive alternatives like
+`individual_mass_in_grams`. Or we would compromise and abbreviate this or 
+leave out some of the words to make it shorter (e.g., `indiv_mass_g`).* 
 
-Have a think about appropriate variable names and then rename the variables in your program to what you find most useful.
+Have a think about appropriate variable names and then rename the variables 
+in your program to what you find most useful.

--- a/exercises/Expressions-variables-5-R.md
+++ b/exercises/Expressions-variables-5-R.md
@@ -5,9 +5,9 @@ subtitle: Modify the Code!
 language: R
 ---
 
-The following code calculates the total net primary productivity (NPP)
-per day for two sites based on the grams of carbon produced per square
-meter per day, and the total area of the sites, and prints them out.
+The following code calculates the total net primary productivity (NPP) per day 
+for two sites based on the grams of carbon produced per square meter per day, 
+and the total area of the sites, and prints them out.
 
 ```
 site1_g_carbon_m2_day <- 5
@@ -20,11 +20,10 @@ print(site1_npp_day)
 print(site2_npp_day)
 ```
 
-Modify the code to produce the following items and print them out in
-order:
+Modify the code to produce the following items and print them out in order:
 
-1.  The sum of the total daily NPP for the two sites combined.
-2.  The difference between the total daily NPP for the two sites. We only want
-    an absolute difference, so use abs() function to make sure the
-    number is positive.
-3.  The total NPP over a year for the two sites combined.
+1. The sum of the total daily NPP for the two sites combined.
+2. The difference between the total daily NPP for the two sites. We only want
+   an absolute difference, so use abs() function to make sure the number is 
+   positive.
+3. The total NPP over a year for the two sites combined.

--- a/exercises/Functions-1-R.md
+++ b/exercises/Functions-1-R.md
@@ -7,20 +7,20 @@ language: R
 
 Use the built-in functions `abs()`, `round()`, `sqrt()`. A built-in function is
 one that you don't need to install and load a package to use. Use another
-function, `help()`, to learn how to use any of the functions that you don't know
-how to use appropriately. `help()` takes one parameter, the name of the function
-you want information about. E.g.,`help(round)`.
+function, `help()`, to learn how to use any of the functions that you don't 
+know how to use appropriately. `help()` takes one parameter, the name of the 
+function you want information about. E.g.,`help(round)`.
 
 1. The absolute value of -15.5.
-2. 4.483847 rounded to one decimal place. The function `round` takes two
+2. 4.483847 rounded to one decimal place. The function `round()` takes two
    arguments, the number to be rounded and the number of decimal places.
 3. 3.8 rounded to the nearest integer. You don't have to specify the number of
-   decimal places in this case if you don't want to, because `round` will
+   decimal places in this case if you don't want to, because `round()` will
    default to using 0 if the second argument is not provided. Look at
    `help(round)` or `?round` to see how this is indicated.
 4. Assign the value of the square root of 2.6 to a variable. Then round the
    variable you've created to 2 decimal places and assign it to another
    variable. Print out the rounded value.
-5. Do the same thing as in problem 4, but instead of creating the intermediate
-   variable, perform both the square root and the round on a single line by
-   putting the `sqrt` call inside the `round` call.
+5. Do the same thing as in problem 4, but instead of creating the 
+   intermediate variable, perform both the square root and the round on a 
+   single line by putting the `sqrt()` call inside the `round()` call.


### PR DESCRIPTION
As per #331.

Looks like `kramdown` does not support code blocks in the same way that `rdiscount` does. This could require a LOT of reformatting. Any ideas? alternates? Seems like GitHub will only be supporting `kramdown`.

Here's the doc for `kramdown`: http://kramdown.gettalong.org/syntax.html . They were nice enough to flag differences between `kramdown` and standard markdown.