### PR TITLE
WIP: Reconcile exercise structure

### DIFF
--- a/_includes/assignment.html
+++ b/_includes/assignment.html
@@ -3,7 +3,7 @@
 {% for exercise in page.exercises %}
   {% for otherpage in site.pages %}
     {% if exercise == otherpage.title and page.language == otherpage.language %}
-      <li><h4>{{ otherpage.subtitle | prepend: "--" | append: "--" }}</h4>
+      <li><h4>{{ otherpage.title | prepend: "-- " | append: ":" }} {{ otherpage.subtitle | append: " --" }}</h4>
         {{ otherpage.content }}
         {% capture output_file %}{{ otherpage.url | remove: 'exercises' | remove: '/' | prepend: '/solutions/' }}{% endcapture %}
         {% for solution in site.static_files %}


### PR DESCRIPTION
The current exercise structure uses `title` and `subtitle` in some opposition. `title` is the file name and key used to link exercises to assignments and back to related exercises (i.e., "This is a follow-up"). `subtitle` is the descriptive tag used in the list of exercises in the assignment. So, when you scroll through an assignment you see a follow-up exercise that has a name you've not seen before unless you've checked out the `exercise/index` or `github.com`. I see a couple of ways to resolve the issue:

1) Make the `title` more visible. This patch adds the exercise title to the `assignments` exercise list, as per #367. With this change, we will want to revise some of the existing `title` & `subtitle`.

2) Update the "follow-up" text with `subtitle`. With this change, some `subtitle` might need to be revised. We might also want to consider changing the format of `exercise/index` and `exercise.html`.

Now that I've seen the start of option 1, I might be leaning towards option 2. Option 2 would partition the need to know the `title` to developers. Students would only see the `subtitle`. 

Any thoughts?

