### PR TITLE
.gitignore: .jekyll-metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ Gemfile.lock
 *~
 #*
 *.Rhistory
+.jekyll-metadata


### PR DESCRIPTION
I am using `jekyll serve --incremental` to optimize rebuilds after local changes. I gain > 20 seconds per change. The process seems to add `.jekyll-metadata`, which we will want to avoid committing.