### PR TITLE
Fix linking after renaming R-sql to R-databases

### DIFF
--- a/lectures/R-databases.md
+++ b/lectures/R-databases.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 element: lecture
-title: Integrating R and SQL
+title: Working with Databases
 language: R
 ---
 


### PR DESCRIPTION
Not all of the name changing was handled in #532. This completes those
changes and restores linking.