### PR TITLE
Fix link to SQL readings on Readings page

### DIFF
--- a/readings/index.md
+++ b/readings/index.md
@@ -5,8 +5,8 @@ title: Readings
 
 ### SQL
 
-* [Introduction to Databases](SQL-intro)
-* [Database Structure and Joins](SQL-joins)
+* [Data Entry and Storage](SQL-data)
+* [Database Queries](SQL-queries)
 
 ### R
 


### PR DESCRIPTION
These links changed after we updated the structure of the first two weeks
but we missed these links.