### PR TITLE
Fix links to external readings

### DIFF
--- a/readings/R-data.md
+++ b/readings/R-data.md
@@ -13,5 +13,5 @@ language: R
 
   * [`dplyr` vignette](https://cran.rstudio.com/web/packages/dplyr/vignettes/introduction.html)
   * *Optional Resources*: 
-    * [Analyzing data with `dplyr`](http://www.datacarpentry.org/R-ecology-lesson/04-dplyr.html)
+    * [Analyzing data with `dplyr`](http://www.datacarpentry.org/R-ecology-lesson/03-dplyr.html)
     * [R for Data Science - Data transformation](http://r4ds.had.co.nz/transform.html)

--- a/readings/R-intro.md
+++ b/readings/R-intro.md
@@ -17,9 +17,8 @@ language: R
 
 * Readings
 
-  * [Getting Started](http://www.datacarpentry.org/R-ecology-lesson//00-before-we-start.html)
-  * [Introduction to R](http://www.datacarpentry.org/R-ecology-lesson//01-intro-to-R.html)
-  * [Starting with data](http://www.datacarpentry.org/R-ecology-lesson//02-starting-with-data.html)
-  * [Introduction to data frames](http://www.datacarpentry.org/R-ecology-lesson//03-data-frames.html)
+  * [Getting Started](http://www.datacarpentry.org/R-ecology-lesson/00-before-we-start.html)
+  * [Introduction to R](http://www.datacarpentry.org/R-ecology-lesson/01-intro-to-r.html)
+  * [Starting with data](http://www.datacarpentry.org/R-ecology-lesson/02-starting-with-data.html)
   * [Vector Reference](http://www.r-tutor.com/r-introduction/vector) (*Read links at bottom*)
   * [Data Frame Reference](http://www.r-tutor.com/r-introduction/data-frame)

--- a/readings/R-sql.md
+++ b/readings/R-sql.md
@@ -12,7 +12,7 @@ language: R
 
 * Readings
 
-  * [SQL databases and R](http://www.datacarpentry.org/R-ecology-lesson/06-r-and-sql.html)
+  * [SQL databases and R](http://www.datacarpentry.org/R-ecology-lesson/05-r-and-databases.html)
   * [`tidyr` vignette](https://cran.r-project.org/web/packages/tidyr/vignettes/tidy-data.html)  
   * *Optional Resources*:  
     * [`tidyr` RStudio Blog](https://blog.rstudio.org/2014/07/22/introducing-tidyr/)

--- a/readings/SQL-data.md
+++ b/readings/SQL-data.md
@@ -7,5 +7,5 @@ language: SQL
 
 
 * [Data Organization](http://kbroman.org/dataorg/)
-* [Quality Assurance and Control](http://www.datacarpentry.org/spreadsheet-ecology-lesson/04-quality-control.html)
-* [Relational Databases Structure and Import](http://www.datacarpentry.org/sql-ecology-lesson/00-sql-introduction.html)
+* [Quality Assurance and Control](http://www.datacarpentry.org/spreadsheet-ecology-lesson/04-quality-control)
+* [Relational Databases Structure and Import](http://www.datacarpentry.org/sql-ecology-lesson/00-sql-introduction)

--- a/readings/SQL-queries.md
+++ b/readings/SQL-queries.md
@@ -6,6 +6,6 @@ language: SQL
 ---
 
 * [Databases Intro](https://www.youtube.com/watch?v=kaKa6N9lEG8)
-* [Basic Queries](http://www.datacarpentry.org/sql-ecology-lesson/01-sql-basic-queries.html) - [Selecting](https://www.youtube.com/watch?v=Gua3FpRzLdQ), [Filtering](https://www.youtube.com/watch?v=c3hoWxukrPE), [Sorting](https://www.youtube.com/watch?v=rNwwdijxxKs), [Nulls](https://www.youtube.com/watch?v=KLugfNdGNFw)
-* Aggregation - [Video](https://www.youtube.com/watch?v=ZjuL-pfkUOA), [Reading](http://www.datacarpentry.org/sql-ecology-lesson/02-sql-aggregation.html)
-* Joins - [Video](https://www.youtube.com/watch?v=79EBoVPUzkE), [Reading](http://www.datacarpentry.org/sql-ecology-lesson/03-sql-joins-aliases.html)
+* [Basic Queries](http://www.datacarpentry.org/sql-ecology-lesson/01-sql-basic-queries) - [Selecting](https://www.youtube.com/watch?v=Gua3FpRzLdQ), [Filtering](https://www.youtube.com/watch?v=c3hoWxukrPE), [Sorting](https://www.youtube.com/watch?v=rNwwdijxxKs), [Nulls](https://www.youtube.com/watch?v=KLugfNdGNFw)
+* Aggregation - [Video](https://www.youtube.com/watch?v=ZjuL-pfkUOA), [Reading](http://www.datacarpentry.org/sql-ecology-lesson/02-sql-aggregation)
+* Joins - [Video](https://www.youtube.com/watch?v=79EBoVPUzkE), [Reading](http://www.datacarpentry.org/sql-ecology-lesson/03-sql-joins-aliases)


### PR DESCRIPTION
A number of Data Carpentry lesson links were apparently moved and not
forwarded over the last fews. This updates them to working versions.