### PR TITLE
Fixing broken link in the instructions for customizing a page

### DIFF
--- a/docs/site/get-site-template.md
+++ b/docs/site/get-site-template.md
@@ -6,7 +6,7 @@ title: Strip Course Content for Site Template
 
 ### From most up-to-date course version on [GitHub]({{ site.github.repo }})...
 
-- Familiarize yourself with the [site]({{ site.baseurl }}/docs/site/site-structure) and [course]({{ site.baseurl }}/docs/site/course-structure) structure.
+- Familiarize yourself with the [site]({{ site.baseurl }}/docs/site/site-directory) and [course]({{ site.baseurl }}/docs/site/course-structure) structure.
   - `_includes/`, `_layouts/`, `nav/`, and `public` contain essential site 
 software for [Jekyll](https://jekyllrb.com/) to render the website from `.HTML` 
 and `.MD` files. These files can be left AS IS for a 'computer programming' 


### PR DESCRIPTION
Link to the site-structure file should, I think, point to the site-directory file now. It currently returns a 404 error, so if it's not the site-directory, it should be something else.