### PR TITLE
Make visual link formats consistent

### DIFF
--- a/lectures/R-data.md
+++ b/lectures/R-data.md
@@ -5,6 +5,6 @@ title: Working with Data
 language: R
 ---
 
-* [`dplyr`]({{ site.baseurl }}/materials/dplyr)
+* [dplyr]({{ site.baseurl }}/materials/dplyr)
 
 

--- a/lectures/R-databases.md
+++ b/lectures/R-databases.md
@@ -5,5 +5,5 @@ title: Working with Databases
 language: R
 ---
 
-1. [`dplyr` with Databases]({{ site.baseurl }}/materials/r-databases)
-2. [`tidyr`]({{ site.baseurl }}/materials/tidyr)
+1. [dplyr with Databases]({{ site.baseurl }}/materials/r-databases)
+2. [tidyr]({{ site.baseurl }}/materials/tidyr)

--- a/lectures/R-datavis.md
+++ b/lectures/R-datavis.md
@@ -5,5 +5,5 @@ title: Data Visualization
 language: R
 ---
 
-* [`ggplot`]({{ site.baseurl }}/materials/ggplot)
+* [ggplot]({{ site.baseurl }}/materials/ggplot)
 

--- a/lectures/R-knitr.md
+++ b/lectures/R-knitr.md
@@ -5,4 +5,4 @@ title: Knitr
 language: R
 ---
 
-[`knitr`]({{ site.baseurl }}/materials/knitr)
+[knitr]({{ site.baseurl }}/materials/knitr)

--- a/readings/R-data.md
+++ b/readings/R-data.md
@@ -11,7 +11,7 @@ language: R
 
 * Readings
 
-  * [`dplyr` vignette](https://cran.r-project.org/web/packages/dplyr/vignettes/dplyr.html)
+  * [dplyr vignette](https://cran.r-project.org/web/packages/dplyr/vignettes/dplyr.html)
   * *Optional Resources*: 
-    * [Analyzing data with `dplyr`](http://www.datacarpentry.org/R-ecology-lesson/03-dplyr.html)
+    * [Analyzing data with dplyr](http://www.datacarpentry.org/R-ecology-lesson/03-dplyr.html)
     * [R for Data Science - Data transformation](http://r4ds.had.co.nz/transform.html)

--- a/readings/R-databases.md
+++ b/readings/R-databases.md
@@ -12,8 +12,8 @@ language: R
 
 * Readings
 
-  * [`dplyr` databases](https://cran.rstudio.com/web/packages/dplyr/vignettes/databases.html)
-  * [`tidyr` vignette](https://cran.r-project.org/web/packages/tidyr/vignettes/tidy-data.html)  
+  * [dplyr databases](https://cran.rstudio.com/web/packages/dplyr/vignettes/databases.html)
+  * [tidyr vignette](https://cran.r-project.org/web/packages/tidyr/vignettes/tidy-data.html)  
   * *Optional Resources*:  
-    * [`tidyr` RStudio Blog](https://blog.rstudio.org/2014/07/22/introducing-tidyr/)
+    * [tidyr RStudio Blog](https://blog.rstudio.org/2014/07/22/introducing-tidyr/)
     * [R for Data Science - Tidy data](http://r4ds.had.co.nz/tidy-data.html)


### PR DESCRIPTION
Links that were composed of package names appeared like code chunks because
of the use of ` for package names. This was confusing to some students who
didn't realize they were links. This removes the ` in links to avoid this
confusion and present a consistent appearance for all links.