### PR TITLE
Add backup copy of bioclim data in case web source goes down

### DIFF
--- a/materials/datasets.md
+++ b/materials/datasets.md
@@ -28,3 +28,4 @@ title: List of datasets
 | DNA sequences | txt | <http://www.datacarpentry.org/semester-biology/data/dna-sequences-1.txt> |
 | Archaea DNA sequences | fasta | <http://www.datacarpentry.org/semester-biology/data/archaea-dna.zip> |
 | Western Ghats tree data | tsv | <http://esapubs.org/archive/ecol/E091/216/Macroplot_data_Rev.txt> |
+| Backup Bioclim Data | zip | <http://www.datacarpentry.org/semester-biology/data/wc10.zip>


### PR DESCRIPTION
The primary data source for `raster::getData` is a UC server
run by a single group. Sometimes, like today, it goes down
when you are about to have students work with it.
This backup copy of the data can be unzipped in the students
home directory and everything will work as expected. This
is `/home/user` on Linux and OSX and `C:\Users\user\Documents`
on Windows.