### PR TITLE
Docs pages should be pages not exercises

### DIFF
--- a/docs/course/contributing.md
+++ b/docs/course/contributing.md
@@ -1,5 +1,5 @@
 ---
-layout: exercise
+layout: page
 topic: Help
 title: Providing Feedback and Contributing New Material
 ---

--- a/docs/course/course-customization.md
+++ b/docs/course/course-customization.md
@@ -1,5 +1,5 @@
 ---
-layout: exercise
+layout: page
 topic: Help
 title: Customizing the Course for Your Needs
 ---

--- a/docs/course/course-delivery.md
+++ b/docs/course/course-delivery.md
@@ -1,5 +1,5 @@
 ---
-layout: exercise
+layout: page
 topic: Help
 title: Teaching Strategies and Course Delivery
 ---

--- a/docs/course/forking-the-course.md
+++ b/docs/course/forking-the-course.md
@@ -1,5 +1,5 @@
 ---
-layout: exercise
+layout: page
 topic: Help
 title: Forking the Course
 ---

--- a/docs/course/manage-files.md
+++ b/docs/course/manage-files.md
@@ -1,5 +1,5 @@
 ---
-layout: exercise
+layout: page
 topic: Help
 title: Manage Course Files
 ---

--- a/docs/course/style-guide.md
+++ b/docs/course/style-guide.md
@@ -1,5 +1,5 @@
 ---
-layout: exercise
+layout: page
 topic: Help
 title: Style Guide
 ---

--- a/docs/site/course-structure.md
+++ b/docs/site/course-structure.md
@@ -1,5 +1,5 @@
 ---
-layout: exercise
+layout: page
 topic: Help
 title: Course Structure
 ---

--- a/docs/site/get-site-template.md
+++ b/docs/site/get-site-template.md
@@ -1,5 +1,5 @@
 ---
-layout: exercise
+layout: page
 topic: Help
 title: Strip Course Content for Site Template
 ---

--- a/docs/site/site-directory.md
+++ b/docs/site/site-directory.md
@@ -1,5 +1,5 @@
 ---
-layout: exercise
+layout: page
 topic: Help
 title: Site Directory
 ---


### PR DESCRIPTION
This will remove the incorrect 'Expected outputs for' language from the
bottom of the pages.

Fixes #918.