### PR TITLE
Add html-proofer github action

### DIFF
--- a/.github/workflows/checklinks.yaml
+++ b/.github/workflows/checklinks.yaml
@@ -1,0 +1,36 @@
+name: CheckLinks
+on:
+  [pull_request]
+  schedule:
+    # Every Sunday at 00:00:00
+    - cron: '0 0 * * 6'
+
+jobs:
+  checklinks:
+    name: Linux
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v2
+      - name: Ruby
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: 2.6.x
+      - name: Setup Rubygems, Bundler, jekyll
+        run: | 
+          gem update --system --no-document
+          gem update bundler --no-document
+          gem install jekyll bundler
+          bundle install
+      - name: Build jekyll website with drafts
+        run: bundle exec jekyll build --drafts
+      - name: Check for broken links
+        run: |
+          bundle exec htmlproofer --log-level :debug ./_site &> links.log
+        continue-on-error: true
+      - name: Archive log links
+        uses: actions/upload-artifact@v1
+        with:
+          name: links-check.log
+          path: links.log


### PR DESCRIPTION
Add github action for checking links using html-proofer based on this tutorial: https://clementbm.github.io/github%20action/jekyll/link%20checking/2020/05/31/automatically-validate-links-on-jekyll-website.html

Set to run on pull request and weekly every Sunday at 00:00:00
