### PR TITLE
Provide more guidance towards easiest approach in size-estimates-by-name exercises

### DIFF
--- a/exercises/Loops-size-estimates-by-name-apply-R.md
+++ b/exercises/Loops-size-estimates-by-name-apply-R.md
@@ -5,16 +5,23 @@ title: Size Estimates By Name Apply
 language: R
 ---
 
+This is a followup to [Size Estimates by Name]({{ site.baseurl }}/exercises/Making-choices-size-estimates-by-name-R).
+
 If the [data on dinosaur lengths with species names]({{ site.baseurl }}/data/dinosaur_lengths.csv) is not in your working directory then download it. Import it using `read.csv()`.
+
+Remember the general form of the equation is:
+
+> mass <- a * length ^ b
 
 Create a function `get_mass_from_length_by_name()` that takes two arguments,
 the `length` and the name of the dinosaur group. Inside this function use
 `if`/`else if`/`else` statements to check to see if the name is one of the
-following values and if so use the associated `a` and `b` values to estimate the species mass.
+following values and if so use the associated `a` and `b` values to estimate the
+species mass using these equations:
 
-* *Stegosauria*:  `a` = `10.95` and `b` = `2.64` ([Seebacher 2001](http://www.jstor.org/stable/4524171)).
-* *Theropoda*:  `a` = `0.73` and `b` = `3.63` ([Seebacher 2001](http://www.jstor.org/stable/4524171)).
-* *Sauropoda*:  `a` = `214.44` and `b` = `1.46` ([Seebacher 2001](http://www.jstor.org/stable/4524171)).
+* *Stegosauria*:  `mass = 10.95 * length ^ 2.64` ([Seebacher 2001](http://www.jstor.org/stable/4524171))
+* *Theropoda*:  `mass = 0.73 * length ^ 3.63` ([Seebacher 2001](http://www.jstor.org/stable/4524171))
+* *Sauropoda*:  `mass = 214.44 * length ^ 1.46` ([Seebacher 2001](http://www.jstor.org/stable/4524171))
 
 If the name is not any of these values the function should return `NA`.
 

--- a/exercises/Loops-size-estimates-by-name-loop-R.md
+++ b/exercises/Loops-size-estimates-by-name-loop-R.md
@@ -10,12 +10,14 @@ This is a followup to [Size Estimates by Name]({{ site.baseurl }}/exercises/Maki
 If `dinosaur_lengths.csv` is not already in your working directory download a copy of the [data on dinosaur lengths with species names]({{ site.baseurl }}/data/dinosaur_lengths.csv). Load it into R.
 
 Write a function `mass_from_length()` that uses the equation `mass <- a * length^b` to estimate the size of a dinosaur from its length.
-This function should take two arguments, `length` and `species`. For each of the following inputs for `species`, use the given values of `a` and `b` for the calculation:
+This function should take two arguments, `length` and `species`. For each of the following inputs for `species`,
+so use the associated `a` and `b` values to estimate the
+species mass using these equations:
 
-* For `Stegosauria`:  `a = 10.95` and `b = 2.64` ([Seebacher 2001](http://www.jstor.org/stable/4524171)).
-* For `Theropoda`:  `a = 0.73` and `b = 3.63` ([Seebacher 2001](http://www.jstor.org/stable/4524171)).
-* For `Sauropoda`:  `a` = `214.44` and `b = 1.46` ([Seebacher 2001](http://www.jstor.org/stable/4524171)).
-* For any other value of `species`: `a = 25.37` and `b = 2.49`.
+* *Stegosauria*:  `mass = 10.95 * length ^ 2.64` ([Seebacher 2001](http://www.jstor.org/stable/4524171)).
+* *Theropoda*:  `mass = 0.73 * length ^ 3.63` ([Seebacher 2001](http://www.jstor.org/stable/4524171)).
+* *Sauropoda*:  `mass = 214.44 * length ^ 1.46` ([Seebacher 2001](http://www.jstor.org/stable/4524171)).
+* For any other value of `species`: `mass = 25.37 * length ^ 2.49`
 
 1. Use this function and a for loop to calculate the estimated mass for each dinosaur, store the masses in a vector, and after all of the calculations are complete show the first few items in the vector using `head()`.
 2. Add the results in the vector back to the original data frame. Show the first few rows of the data frame using `head()`.

--- a/exercises/Making-choices-size-estimates-by-name-R.md
+++ b/exercises/Making-choices-size-estimates-by-name-R.md
@@ -12,14 +12,19 @@ decide to create a function that lets you specify which dinosaur group you need
 to estimate the size of by name and then have the function automatically choose
 the right parameters.
 
+Remember the general form of the equation is:
+
+> mass <- a * length ^ b
+
 Create a new function `get_mass_from_length_by_name()` that takes two arguments,
 the `length` and the name of the dinosaur group. Inside this function use
 `if`/`else if`/`else` statements to check to see if the name is one of the
-following values and if so use the associated `a` and `b` values to estimate the species mass.
+following values and if so use the associated `a` and `b` values to estimate the
+species mass using these equations:
 
-* *Stegosauria*:  `a` = `10.95` and `b` = `2.64` ([Seebacher 2001](http://www.jstor.org/stable/4524171)).
-* *Theropoda*:  `a` = `0.73` and `b` = `3.63` ([Seebacher 2001](http://www.jstor.org/stable/4524171)).
-* *Sauropoda*:  `a` = `214.44` and `b` = `1.46` ([Seebacher 2001](http://www.jstor.org/stable/4524171)).
+* *Stegosauria*:  `mass = 10.95 * length ^ 2.64` ([Seebacher 2001](http://www.jstor.org/stable/4524171))
+* *Theropoda*:  `mass = 0.73 * length ^ 3.63` ([Seebacher 2001](http://www.jstor.org/stable/4524171))
+* *Sauropoda*:  `mass = 214.44 * length ^ 1.46` ([Seebacher 2001](http://www.jstor.org/stable/4524171))
 
 If the name is not any of these values the function should return `NA`.
 


### PR DESCRIPTION
These exercises where already rewritten to try to guide students towards using `mass = a * length ^ b` in each conditional, but many are still trying to set `a` and `b` which leads to confusion about how to handle `mass = NA`. This revision attempts to be really explicit about using the equations.