### PR TITLE
replace links to previous version of R-ecology-lesson

### DIFF
--- a/materials/Walkthrough-R.md
+++ b/materials/Walkthrough-R.md
@@ -158,4 +158,4 @@ The hardest part here is finding the right keywords to use.
 - [Hadley Wickham](http://adv-r.had.co.nz/Style.html)
 - [Google](https://google-styleguide.googlecode.com/svn/trunk/Rguide.xml)
 
-*This document benefited greatly by the inclusion of Data Carpentry materials ([Before we start](http://www.datacarpentry.org/R-ecology-lesson/00-before-we-start.html), [Introduction to R](http://www.datacarpentry.org/R-ecology-lesson/01-intro-to-R.html)) and Software Carpentry's ([Programming with R Reference](http://swcarpentry.github.io/r-novice-inflammation/reference/))*
+*This document benefited greatly by the inclusion of Data Carpentry materials (_Before we start_, _Introduction to R_, both now [archived](https://zenodo.org/records/12684301)) and Software Carpentry's ([Programming with R Reference](http://swcarpentry.github.io/r-novice-inflammation/reference/))*

--- a/readings/R-aggregation-joins.md
+++ b/readings/R-aggregation-joins.md
@@ -12,5 +12,5 @@ language: R
 
 ### Optional Resources:
  
-* [Analyzing data with dplyr](http://www.datacarpentry.org/R-ecology-lesson/03-dplyr.html)
+* [Data Analysis and Visualization in R for Ecologists - Working with data](http://www.datacarpentry.org/R-ecology-lesson/working-with-data.html)
 * [dplyr vignette](https://cran.r-project.org/web/packages/dplyr/vignettes/dplyr.html)

--- a/readings/R-data.md
+++ b/readings/R-data.md
@@ -11,5 +11,5 @@ language: R
 
 ### Optional Resources:
  
-* [Analyzing data with dplyr](http://www.datacarpentry.org/R-ecology-lesson/03-dplyr.html)
+* [Data Analysis and Visualization in R for Ecologists - Working with data](http://www.datacarpentry.org/R-ecology-lesson/working-with-data.html)
 * [dplyr vignette](https://cran.r-project.org/web/packages/dplyr/vignettes/dplyr.html)

--- a/readings/R-intro.md
+++ b/readings/R-intro.md
@@ -19,7 +19,7 @@ language: R
 
 #### Introduction to RStudio (choose one)
 
-* Reading: [Before We Start (Data Carpentry Lesson)](http://www.datacarpentry.org/R-ecology-lesson/00-before-we-start.html)
+* Reading: [Introduction to R and RStudio (Data Carpentry Lesson)](https://datacarpentry.org/R-ecology-lesson/introduction-r-rstudio.html)
 * Video (15 min): [An opinionated tour of RStudio (R-Ladies Sydney)](https://www.youtube.com/watch?v=kfcX5DEMAp4)
 
 #### Introduction to R
@@ -28,4 +28,4 @@ language: R
 
 #### Starting with Data
 
-* [Starting with data (**only through "Inspecting data.frame Objects"**)](http://www.datacarpentry.org/R-ecology-lesson/02-starting-with-data.html)
+* [Exploring and understanding data (**only through "The data.frame"**)](https://datacarpentry.org/R-ecology-lesson/how-r-thinks-about-data.html)

--- a/readings/R-intro.md
+++ b/readings/R-intro.md
@@ -24,7 +24,8 @@ language: R
 
 #### Introduction to R
 
-* [Introduction to R](http://www.datacarpentry.org/R-ecology-lesson/01-intro-to-r.html)
+* [An Introduction to R - Getting Started](https://intro2r.com/getting-started.html)
+* [An Introduction to R - Objects in R](https://intro2r.com/objects-in-r.html)
 
 #### Starting with Data
 


### PR DESCRIPTION
Partly addresses #1035

This updates some of the links to the previous version of R-ecology-lesson. There are a few left that I am unsure of how to handle.

- [x] in `readings/R-intro.md`, there is a link to `[Introduction to R](http://www.datacarpentry.org/R-ecology-lesson/01-intro-to-r.html)`. The problem here is that the redesigned lesson takes a "ggplot2-first" approach, and I am not sure if [that episode](https://datacarpentry.org/R-ecology-lesson/visualizing-ggplot.html) introduces the concepts you want at this stage of the course.
- [ ] in `readings/R-databases.md`, there is a link to `[Data Management with SQL for Ecologists](https://datacarpentry.org/sql-ecology-lesson/)`. The redesigned lesson does not include content on `dbplyr`, so I cannot provide a ready replacement for this link. Sorry!

Any thoughts on how these two cases should be handled, @ethanwhite? 
