### PR TITLE
Don't show soln links for exercises with no solns

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,6 +8,12 @@ kramdown:
 # Permalinks
 permalink:        pretty
 
+# Exercises with no solutions
+no_solution:
+  - "https://dcsem-solutions.weecology.org/solutions/Tidy-data-improving-messy-data-SQL"
+  - "https://dcsem-solutions.weecology.org/solutions/Qaqc-data-entry-validation-in-excel-SQL"
+  - "https://dcsem-solutions.weecology.org/solutions/Tidy-data-clean-up-SQL"
+
 # Setup
 title:            Data Carpentry for Biologists
 description:      'Teaching the tools to get computers to do cool science'

--- a/_includes/assignment.html
+++ b/_includes/assignment.html
@@ -1,4 +1,5 @@
 <h3> Exercises </h3>
+
 <ol>
 {% for exercise in page.exercises %}
   {% assign exercise_loop = forloop %}
@@ -14,7 +15,9 @@
         {% endif %}
         {{ otherpage.content }}
         {% capture output_url %}{{ otherpage.url | remove: 'exercises' | remove: 'docs/templates' | remove: '/' | prepend: 'https://dcsem-solutions.weecology.org/solutions/' }}{% endcapture %}
-        <em><a href="{{ output_url }}" aria-label="Expected output for {{otherpage.title}}">Expected outputs for {{ otherpage.title }}</a></em>
+        {% unless site.no_solution contains output_url %}
+          <em><a href="{{ output_url }}" aria-label="Expected output for {{otherpage.title}}">Expected outputs for {{ otherpage.title }}</a></em>
+        {% endunless %}
         {% capture output_file %}{{ otherpage.url | remove: 'exercises' | remove: 'docs/templates'| remove: '/' | prepend: '/solutions/' }}{% endcapture %}
         {% assign loop_count = 0 %}
       </li>

--- a/_layouts/exercise.html
+++ b/_layouts/exercise.html
@@ -6,5 +6,7 @@ layout: default
   <h1>{{ page.title }} ({{ page.topic }})</h1>
   {{ content }}
   {% capture output_url %}{{ page.url | remove: 'exercises' | remove: 'docs/templates' | remove: '/' | prepend: 'https://dcsem-solutions.weecology.org/solutions/' }}{% endcapture %}
-  <em><a href="{{ output_url }}" aria-label="Expected output for {{page.title}}">Expected outputs for {{ page.title }}</a></em>
+  {% unless site.no_solution contains output_url %}
+    <em><a href="{{ output_url }}" aria-label="Expected output for {{page.title}}">Expected outputs for {{ page.title }}</a></em>
+  {% endunless %}
 </div>


### PR DESCRIPTION
Some exercises don't have solutions because there is no good way to display them. This allows them to be listed in _config.yml and then no solutions link is rendered.

This is a little bit of a hack, but necessary for a gradual infrastructure upgrade.