### PR TITLE
changed broken link to Lyons et al. 2004 paper

### DIFF
--- a/exercises/Repro-megafaunal-extinction.md
+++ b/exercises/Repro-megafaunal-extinction.md
@@ -10,7 +10,7 @@ There were a relatively large number of extinctions of mammalian species roughly
 are interested in understanding if there were differences in the size of the
 species that went extinct and those that did not. You are going to reproduce the
 three main figures from one of the major papers on this topic [Lyons et al.
-2004](http://www.evolutionary-ecology.com/issues/v06n03/ddar1499.pdf).
+2004](https://onlinelibrary.wiley.com/doi/full/10.1111/j.1461-0248.2004.00643.x).
 
 You will do this using a 
 [large dataset of mammalian body sizes]({{ site.baseurl }}/data/mammal-size-data-clean.tsv)


### PR DESCRIPTION
_If this pull request addresses an open issue on the repository, please add 'Closes #NN' below, where NN is the issue number._

Closes 
#1162


_Please briefly summarise the changes made in the pull request, and the reason(s) for making these changes._

https://datacarpentry.github.io/semester-biology/exercises/Repro-megafaunal-extinction/ had broken link to paper, added new link that takes students to https://onlinelibrary.wiley.com/doi/full/10.1111/j.1461-0248.2004.00643.x 

_If any relevant discussions have taken place elsewhere, please provide links to these._


<details>

For more guidance on how to contribute changes to a Carpentries project, please review [the Contributing Guide](CONTRIBUTING.md) and [Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html).

Please keep in mind that lesson Maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum. If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact The Carpentries Team at team@carpentries.org.

</details>
