### PR TITLE
Fix ci ruby

### DIFF
--- a/.github/workflows/checklinks.yml
+++ b/.github/workflows/checklinks.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.3'
-          bundler-cache: true
+          bundler-cache: true 
       - run: |
           bundle install
           gem install html-proofer

--- a/.github/workflows/checklinks.yml
+++ b/.github/workflows/checklinks.yml
@@ -16,10 +16,11 @@ jobs:
     name: Linux
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-ruby@v1
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.6.x
+          ruby-version: '3.3'
+          bundler-cache: true
       - run: |
           bundle install
           gem install html-proofer

--- a/.github/workflows/pa11y.yml
+++ b/.github/workflows/pa11y.yml
@@ -11,12 +11,12 @@ jobs:
 
     steps:
       - name: Checkout source.
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install jekyll site dependencies.
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.6
+          ruby-version: '3.3'
           bundler-cache: true
 
       - name: Install pa11y-ci dependencies.

--- a/.github/workflows/pa11y.yml
+++ b/.github/workflows/pa11y.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Read pa11y_output file.
         id: pa11y_output
         uses: juliangruber/read-file-action@v1
-        with:
+        with: 
           path: ./pa11y_output.txt
         
       - name: Comment on pull request.

--- a/.github/workflows/pa11y.yml
+++ b/.github/workflows/pa11y.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Read pa11y_output file.
         id: pa11y_output
         uses: juliangruber/read-file-action@v1
-        with: 
+        with:
           path: ./pa11y_output.txt
         
       - name: Comment on pull request.

--- a/.github/workflows/pa11y.yml
+++ b/.github/workflows/pa11y.yml
@@ -27,6 +27,8 @@ jobs:
 
       - name: Run pa11y-ci.
         run: npm run pa11y-ci:sitemap 2>&1 | tee pa11y_output.txt
+        env:
+        PUPPETEER_ARGS: --no-sandbox --disable-setuid-sandbox
         
       - name: Read pa11y_output file.
         id: pa11y_output


### PR DESCRIPTION
_If this pull request addresses an open issue on the repository, please add 'Closes #NN' below, where NN is the issue number._


_Please briefly summarise the changes made in the pull request, and the reason(s) for making these changes._

workflows failing because Ruby 2.6 is no longer available/supported in the hosted CI environment, and the bundle now includes dependencies such as nokogiri that require Ruby 3.0 or newer. The old Ruby setup action was also deprecated.

_If any relevant discussions have taken place elsewhere, please provide links to these._


<details>

For more guidance on how to contribute changes to a Carpentries project, please review [the Contributing Guide](CONTRIBUTING.md) and [Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html).

Please keep in mind that lesson Maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum. If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact The Carpentries Team at team@carpentries.org.

</details>
